### PR TITLE
ThemeToggleコンポーネントをMUI Switch風のデザインに変更 (#10)

### DIFF
--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -2,66 +2,126 @@
 
 ---
 
-<button id="theme-toggle" aria-label="テーマを切り替え">
-  <span class="sun-icon">☀️</span>
-  <span class="moon-icon">🌙</span>
-</button>
+<div class="theme-switch-wrapper">
+  <label class="theme-switch" for="theme-toggle">
+    <input type="checkbox" id="theme-toggle" />
+    <div class="slider">
+      <div class="thumb">
+        <span class="icon sun-icon">☀️</span>
+        <span class="icon moon-icon">🌙</span>
+      </div>
+    </div>
+  </label>
+</div>
 
 <style>
-  #theme-toggle {
-    background: none;
-    border: 2px solid var(--color-border);
-    border-radius: 20px;
-    width: 40px;
-    height: 24px;
+  .theme-switch-wrapper {
+    display: flex;
+    align-items: center;
+  }
+
+  .theme-switch {
+    position: relative;
+    display: inline-block;
+    width: 60px;
+    height: 34px;
+  }
+
+  .theme-switch input {
+    opacity: 0;
+    width: 0;
+    height: 0;
+  }
+
+  .slider {
+    position: absolute;
     cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border-radius: 34px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  }
+
+  .slider:hover {
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+  }
+
+  .thumb {
+    position: absolute;
+    height: 26px;
+    width: 26px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    border-radius: 50%;
     display: flex;
     align-items: center;
     justify-content: center;
-    position: relative;
-    transition: all 0.3s ease;
-    padding: 0;
-    overflow: hidden;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
   }
 
-  #theme-toggle:hover {
-    background-color: var(--color-hover);
-    border-color: var(--color-primary);
-  }
-
-  .sun-icon,
-  .moon-icon {
-    font-size: 12px;
+  .icon {
     position: absolute;
-    transition:
-      transform 0.3s ease,
-      opacity 0.3s ease;
+    font-size: 14px;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   }
 
   .sun-icon {
-    transform: translateX(0) scale(1);
     opacity: 1;
+    transform: scale(1);
   }
 
   .moon-icon {
-    transform: translateX(0) scale(0.8);
     opacity: 0;
+    transform: scale(0.6);
   }
 
-  [data-theme="dark"] .sun-icon {
-    transform: translateX(0) scale(0.8);
-    opacity: 0;
+  /* Checked state - dark mode */
+  input:checked + .slider {
+    background-color: #2196f3;
   }
 
-  [data-theme="dark"] .moon-icon {
-    transform: translateX(0) scale(1);
+  input:checked + .slider .thumb {
+    transform: translateX(26px);
+  }
+
+  input:checked + .slider .sun-icon {
+    opacity: 0;
+    transform: scale(0.6);
+  }
+
+  input:checked + .slider .moon-icon {
     opacity: 1;
+    transform: scale(1);
+  }
+
+  /* Dark theme colors */
+  [data-theme="dark"] .slider {
+    background-color: #424242;
+  }
+
+  [data-theme="dark"] input:checked + .slider {
+    background-color: #1976d2;
+  }
+
+  [data-theme="dark"] .thumb {
+    background-color: #f5f5f5;
+  }
+
+  /* Focus styles for accessibility */
+  input:focus + .slider {
+    box-shadow: 0 0 0 2px rgba(33, 150, 243, 0.3);
   }
 </style>
 
 <script>
   function initThemeToggle() {
-    const toggle = document.getElementById("theme-toggle");
+    const toggle = document.getElementById("theme-toggle") as HTMLInputElement;
     const html = document.documentElement;
 
     // システム設定に基づく初期テーマ検出
@@ -80,6 +140,11 @@
     function setTheme(theme: string) {
       html.setAttribute("data-theme", theme);
       localStorage.setItem("theme", theme);
+
+      // チェックボックスの状態も更新
+      if (toggle) {
+        toggle.checked = theme === "dark";
+      }
     }
 
     // テーマを切り替える関数
@@ -93,8 +158,8 @@
     const initialTheme = getInitialTheme();
     setTheme(initialTheme);
 
-    // クリックイベントリスナー
-    toggle?.addEventListener("click", toggleTheme);
+    // changeイベントリスナー（チェックボックス用）
+    toggle?.addEventListener("change", toggleTheme);
 
     // システム設定変更の監視
     window


### PR DESCRIPTION
## Summary
- 現在の太陽/月アイコンボタンからMUI Switch風のトグルスイッチ形式に変更
- アクセシブルなチェックボックス形式の実装
- スムーズなアニメーションとホバーエフェクト

## Changes
- ThemeToggle.astroのHTML構造をラベル+チェックボックス+スライダーに変更
- MUIスタイルのCSS（背景色、サム、トランジション）を実装
- JavaScript側でチェックボックスの状態同期を追加

## Test plan
- [x] ライトモードでスイッチが左側（オフ）になることを確認
- [x] ダークモードでスイッチが右側（オン）になることを確認
- [x] スイッチクリックでテーマが正常に切り替わることを確認
- [x] アニメーションが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)