### PR TITLE
Astroからの警告の対応

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(git push:*)",
       "Bash(gh pr create:*)",
       "Bash(yarn format)",
-      "Bash(yarn dev)"
+      "Bash(yarn dev)",
+      "Bash(gh issue comment:*)"
     ],
     "deny": [],
     "ask": []

--- a/package.json
+++ b/package.json
@@ -29,10 +29,14 @@
     "@eslint/js": "^9.34.0",
     "@typescript-eslint/eslint-plugin": "^8.42.0",
     "@typescript-eslint/parser": "^8.42.0",
+    "baseline-browser-mapping": "^2.10.0",
     "eslint": "^9.34.0",
     "eslint-plugin-astro": "^1.3.1",
     "prettier": "3.6.2",
     "prettier-plugin-astro": "0.14.1",
     "typescript": "^5.9.2"
+  },
+  "resolutions": {
+    "baseline-browser-mapping": "^2.10.0"
   }
 }

--- a/src/components/organisms/News.astro
+++ b/src/components/organisms/News.astro
@@ -1,15 +1,26 @@
 ---
-import type { MarkdownInstance } from "astro";
 import DateStr from "@components/atoms/DateStr.astro";
 
+type PostFrontmatter = {
+  title: string;
+  date: string;
+  description: string;
+};
+
 // 最新ニュース3件を取得
-const allPosts = await Astro.glob<
-  MarkdownInstance<{
-    title: string;
-    date: string;
-    description: string;
-  }>
->("../../pages/news/posts/*.{md,mdx}");
+const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
+  "../../pages/news/posts/*.{md,mdx}",
+);
+
+const allPosts = await Promise.all(
+  Object.entries(postModules).map(async ([path, loader]) => {
+    const mod = await loader();
+    const url = path
+      .replace(/^\.\.\/\.\.\/pages\/news\/posts\//, "/news/posts/")
+      .replace(/\.(md|mdx)$/, "");
+    return { frontmatter: mod.frontmatter, url };
+  }),
+);
 
 // 日付でソート（新しい順）して最新3件を取得
 const latestPosts = allPosts

--- a/src/layouts/PortfolioLayout.astro
+++ b/src/layouts/PortfolioLayout.astro
@@ -45,17 +45,33 @@ const hasMultipleImages = validProductImages.length > 1;
 const productImage = validProductImages[0] || null;
 
 // ポートフォリオページの一覧を取得
-const portfolioPages = await Astro.glob("../pages/portfolio/*.mdx");
-const sortedPortfolioPages = portfolioPages
-  .map((module) => ({
-    frontmatter: module.frontmatter,
-    url: module.url || "",
-  }))
-  .sort(
-    (a, b) =>
-      new Date(b.frontmatter.date).getTime() -
-      new Date(a.frontmatter.date).getTime(),
-  );
+type PortfolioFrontmatter = {
+  title: string;
+  date: string;
+  icon: string;
+  image: string[];
+  description: string;
+};
+
+const portfolioModules = import.meta.glob<{
+  frontmatter: PortfolioFrontmatter;
+}>("../pages/portfolio/*.mdx");
+
+const portfolioPages = await Promise.all(
+  Object.entries(portfolioModules).map(async ([path, loader]) => {
+    const mod = await loader();
+    const url = path
+      .replace(/^\.\.\/pages\/portfolio\//, "/portfolio/")
+      .replace(/\.mdx$/, "");
+    return { frontmatter: mod.frontmatter, url };
+  }),
+);
+
+const sortedPortfolioPages = portfolioPages.sort(
+  (a, b) =>
+    new Date(b.frontmatter.date).getTime() -
+    new Date(a.frontmatter.date).getTime(),
+);
 
 // 現在のページURL
 const currentPageUrl = Astro.url.pathname;

--- a/src/pages/news/index.astro
+++ b/src/pages/news/index.astro
@@ -1,18 +1,29 @@
 ---
-import type { MarkdownInstance } from "astro";
 import Layout from "@layouts/Layout.astro";
 import NewsHeader from "@components/molecules/NewsHeader.astro";
 
+type PostFrontmatter = {
+  title: string;
+  type: string;
+  date: string;
+  image: string;
+  description: string;
+};
+
 // すべてのニュース記事を取得
-const allPosts = await Astro.glob<
-  MarkdownInstance<{
-    title: string;
-    type: string;
-    date: string;
-    image: string;
-    description: string;
-  }>
->("./posts/*.{md,mdx}");
+const postModules = import.meta.glob<{ frontmatter: PostFrontmatter }>(
+  "./posts/*.{md,mdx}",
+);
+
+const allPosts = await Promise.all(
+  Object.entries(postModules).map(async ([path, loader]) => {
+    const mod = await loader();
+    const url = path
+      .replace(/^\.\/posts\//, "/news/posts/")
+      .replace(/\.(md|mdx)$/, "");
+    return { frontmatter: mod.frontmatter, url };
+  }),
+);
 
 // 日付でソート（新しい順）
 const sortedPosts = allPosts.sort((a, b) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1574,10 +1574,10 @@ base64-js@^1.1.2, base64-js@^1.3.0:
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
 
-baseline-browser-mapping@^2.8.19:
-  version "2.8.25"
-  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.8.25.tgz#947dc6f81778e0fa0424a2ab9ea09a3033e71109"
-  integrity sha512-2NovHVesVF5TXefsGX1yzx1xgr7+m9JQenvz6FQY3qd+YXkKkYiv+vTCc7OriP9mcDZpTC5mAOYN4ocd29+erA==
+baseline-browser-mapping@^2.10.0, baseline-browser-mapping@^2.8.19:
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.0.tgz#5b09935025bf8a80e29130251e337c6a7fc8cbb9"
+  integrity sha512-lIyg0szRfYbiy67j9KN8IyeD7q7hcmqnJ1ddWmNt19ItGpNN64mnllmxUNFIOdOm6by97jlL6wfpTTJrmnjWAA==
 
 boxen@8.0.1:
   version "8.0.1"


### PR DESCRIPTION
## 概要

- Astroから出力されていた以下の非推奨警告を解消します。

> Astro.glob is deprecated and will be removed in a future major version of Astro.
> Use import.meta.glob instead: https://vitejs.dev/guide/features.html#glob-import

- Astroから出力されていた以下の警告を解消します。
> [baseline-browser-mapping] The data in this module is over two months old.  To ensure accurate Baseline data,  please update: `npm i baseline-browser-mapping@latest -D`

## 変更内容

- `src/pages/news/index.astro` — `Astro.glob` → `import.meta.glob` に置き換え、`MarkdownInstance` インポートを削除
- `src/layouts/PortfolioLayout.astro` — `Astro.glob` → `import.meta.glob` に置き換え
- `src/components/organisms/News.astro` — `Astro.glob` → `import.meta.glob` に置き換え、`MarkdownInstance` インポートを削除

Vite の `import.meta.glob` はキーに相対パスをそのまま返すため、各ファイルのグロブパターンに合わせた正規表現でURLを生成しています。

## テスト計画

- [x] ニュース一覧ページ (`/news`) が正常に表示される
- [x] ニュース記事ページ (`/news/posts/*`) が正常に表示される
- [x] ポートフォリオページ (`/portfolio/*`) が正常に表示される
- [x] トップページのNewsコンポーネントが正常に表示される
- [x] Astroの非推奨警告が出力されなくなっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)