### PR TITLE
トップページのデスクイメージをThree.jsの3Dシーンに置き換え

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,7 +19,12 @@ export default [
         localStorage: "readonly",
         MediaQueryListEvent: "readonly",
         HTMLInputElement: "readonly",
+        HTMLDivElement: "readonly",
         MutationObserver: "readonly",
+        ResizeObserver: "readonly",
+        PointerEvent: "readonly",
+        requestAnimationFrame: "readonly",
+        cancelAnimationFrame: "readonly",
       },
     },
     plugins: {

--- a/package.json
+++ b/package.json
@@ -21,9 +21,11 @@
     "@splidejs/splide": "^4.1.4",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
+    "@types/three": "^0.183.0",
     "astro": "^5.13.5",
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "three": "^0.183.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.34.0",

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -169,10 +169,11 @@ export default function DeskScene({
       const iconMat = new THREE.MeshBasicMaterial({
         map: texture,
         transparent: true,
+        side: THREE.DoubleSide,
       });
-      iconPlane = new THREE.Mesh(new THREE.PlaneGeometry(0.45, 0.45), iconMat);
-      iconPlane.position.set(-0.3, 0.185, -0.1);
-      iconPlane.rotation.x = -Math.PI / 2;
+      iconPlane = new THREE.Mesh(new THREE.PlaneGeometry(0.65, 0.65), iconMat);
+      iconPlane.position.set(-1.0, 0.385, -0.3);
+      //iconPlane.rotation.x = -Math.PI / 2;
       scene.add(iconPlane);
     });
 

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -74,7 +74,7 @@ export default function DeskScene({
       0.1,
       1000,
     );
-    camera.position.set(1, 5, 6);
+    camera.position.set(-4, 0, 1);
     camera.lookAt(0, 0, 0);
 
     // Lighting

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -87,7 +87,6 @@ export default function DeskScene({
 
     // Materials
     const grayMat = new THREE.MeshLambertMaterial({ color: 0xd9d9d9 });
-    const darkGrayMat = new THREE.MeshLambertMaterial({ color: 0x888888 });
     const whiteMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
 
     // Desk top
@@ -112,53 +111,54 @@ export default function DeskScene({
       scene.add(leg);
     }
 
-    // Monitor body
-    const monitor = new THREE.Mesh(
-      new THREE.BoxGeometry(1.5, 1.0, 0.08),
-      darkGrayMat,
-    );
-    monitor.position.set(-0.3, 0.65, -0.7);
-    scene.add(monitor);
+    // // Monitor body
+    // const monitor = new THREE.Mesh(
+    //   new THREE.BoxGeometry(1.5, 1.0, 0.08),
+    //   darkGrayMat,
+    // );
+    // monitor.position.set(-0.3, 0.65, -0.7);
+    // scene.add(monitor);
+    //
+    // // Monitor stand
+    // const monitorStand = new THREE.Mesh(
+    //   new THREE.CylinderGeometry(0.05, 0.08, 0.4, 8),
+    //   grayMat,
+    // );
+    // monitorStand.position.set(-0.3, 0.275, -0.7);
+    // scene.add(monitorStand);
+    //
+    // // Monitor base
+    // const monitorBase = new THREE.Mesh(
+    //   new THREE.BoxGeometry(0.5, 0.05, 0.3),
+    //   grayMat,
+    // );
+    // monitorBase.position.set(-0.3, 0.075, -0.7);
+    // scene.add(monitorBase);
 
-    // Monitor stand
-    const monitorStand = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.05, 0.08, 0.4, 8),
-      grayMat,
-    );
-    monitorStand.position.set(-0.3, 0.275, -0.7);
-    scene.add(monitorStand);
-
-    // Monitor base
-    const monitorBase = new THREE.Mesh(
-      new THREE.BoxGeometry(0.5, 0.05, 0.3),
-      grayMat,
-    );
-    monitorBase.position.set(-0.3, 0.075, -0.7);
-    scene.add(monitorBase);
-
-    // Mouse
-    const mouse = new THREE.Mesh(
-      new THREE.BoxGeometry(0.2, 0.08, 0.3),
-      grayMat,
-    );
-    mouse.position.set(0.8, 0.115, 0.1);
-    scene.add(mouse);
+    // // Mouse
+    // const mouse = new THREE.Mesh(
+    //   new THREE.BoxGeometry(0.2, 0.08, 0.3),
+    //   grayMat,
+    // );
+    // mouse.position.set(0.8, 0.115, 0.1);
+    // scene.add(mouse);
 
     // Coffee cup body
     const cupBody = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.1, 0.08, 0.25, 16),
+      new THREE.CylinderGeometry(0.15, 0.12, 0.375, 16),
       whiteMat,
     );
-    cupBody.position.set(1.4, 0.2, -0.5);
+    cupBody.position.set(1.3, 0.2625, 0.55);
     scene.add(cupBody);
 
     // Coffee cup handle
     const cupHandle = new THREE.Mesh(
-      new THREE.TorusGeometry(0.06, 0.015, 8, 8, Math.PI),
+      new THREE.TorusGeometry(0.09, 0.0225, 8, 8, Math.PI),
       whiteMat,
     );
-    cupHandle.position.set(1.5, 0.2, -0.5);
-    cupHandle.rotation.y = Math.PI / 2;
+    cupHandle.position.set(1.45, 0.2625, 0.55);
+    cupHandle.rotation.y = Math.PI / 1;
+    cupHandle.rotation.z = Math.PI / 2;
     scene.add(cupHandle);
 
     // RightCheat icon plane

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -326,8 +326,7 @@ export default function DeskScene({
           p.startZ + p.driftZ * t,
         );
         // Fade in (0→30%) then fade out (30→100%)
-        const opacity =
-          t < 0.3 ? (t / 0.3) * 0.45 : ((1 - t) / 0.7) * 0.45;
+        const opacity = t < 0.3 ? (t / 0.3) * 0.45 : ((1 - t) / 0.7) * 0.45;
         (p.mesh.material as THREE.MeshBasicMaterial).opacity = opacity;
         // Grow as it rises
         const scale = 0.6 + t * 1.8;

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -198,7 +198,7 @@ export default function DeskScene({
         side: THREE.DoubleSide,
         depthWrite: false,
       });
-      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(0.08, 0.12), mat);
+      const mesh = new THREE.Mesh(new THREE.CircleGeometry(0.05, 16), mat);
       scene.add(mesh);
 
       const data: SteamParticleData = {

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -161,6 +161,59 @@ export default function DeskScene({
     cupHandle.rotation.z = Math.PI / 2;
     scene.add(cupHandle);
 
+    // Steam particles
+    const CUP_X = 1.3;
+    const CUP_Z = 0.55;
+    const CUP_TOP_Y = 0.45; // 0.2625 + 0.375 / 2
+    const STEAM_COUNT = 8;
+
+    type SteamParticleData = {
+      mesh: THREE.Mesh;
+      life: number;
+      maxLife: number;
+      speed: number;
+      startX: number;
+      startZ: number;
+      driftX: number;
+      driftZ: number;
+    };
+
+    const steamParticles: SteamParticleData[] = [];
+
+    const resetSteam = (p: SteamParticleData) => {
+      p.life = 0;
+      p.maxLife = 1.5 + Math.random() * 0.8;
+      p.speed = 0.25 + Math.random() * 0.15;
+      p.startX = CUP_X + (Math.random() - 0.5) * 0.12;
+      p.startZ = CUP_Z + (Math.random() - 0.5) * 0.12;
+      p.driftX = (Math.random() - 0.5) * 0.12;
+      p.driftZ = (Math.random() - 0.5) * 0.12;
+    };
+
+    for (let i = 0; i < STEAM_COUNT; i++) {
+      const mat = new THREE.MeshBasicMaterial({
+        color: 0xdddddd,
+        transparent: true,
+        opacity: 0,
+        side: THREE.DoubleSide,
+        depthWrite: false,
+      });
+      const mesh = new THREE.Mesh(new THREE.PlaneGeometry(0.08, 0.12), mat);
+      scene.add(mesh);
+
+      const data: SteamParticleData = {
+        mesh,
+        life: Math.random() * 2.3, // staggered start
+        maxLife: 1.5 + Math.random() * 0.8,
+        speed: 0.25 + Math.random() * 0.15,
+        startX: CUP_X + (Math.random() - 0.5) * 0.12,
+        startZ: CUP_Z + (Math.random() - 0.5) * 0.12,
+        driftX: (Math.random() - 0.5) * 0.12,
+        driftZ: (Math.random() - 0.5) * 0.12,
+      };
+      steamParticles.push(data);
+    }
+
     // RightCheat icon plane
     const textureLoader = new THREE.TextureLoader();
     let iconPlane: THREE.Mesh | null = null;
@@ -253,9 +306,36 @@ export default function DeskScene({
     resizeObserver.observe(container);
 
     // Animation loop
+    const clock = new THREE.Clock();
     let animId: number;
     const animate = () => {
       animId = requestAnimationFrame(animate);
+
+      const delta = clock.getDelta();
+
+      // Update steam particles
+      for (const p of steamParticles) {
+        p.life += delta;
+        if (p.life > p.maxLife) {
+          resetSteam(p);
+        }
+        const t = p.life / p.maxLife;
+        p.mesh.position.set(
+          p.startX + p.driftX * t,
+          CUP_TOP_Y + p.speed * p.life,
+          p.startZ + p.driftZ * t,
+        );
+        // Fade in (0→30%) then fade out (30→100%)
+        const opacity =
+          t < 0.3 ? (t / 0.3) * 0.45 : ((1 - t) / 0.7) * 0.45;
+        (p.mesh.material as THREE.MeshBasicMaterial).opacity = opacity;
+        // Grow as it rises
+        const scale = 0.6 + t * 1.8;
+        p.mesh.scale.set(scale, scale, scale);
+        // Billboard: always face camera
+        p.mesh.quaternion.copy(camera.quaternion);
+      }
+
       controls.update();
       renderer.render(scene, camera);
     };

--- a/src/components/organisms/DeskScene.tsx
+++ b/src/components/organisms/DeskScene.tsx
@@ -1,0 +1,296 @@
+import { useEffect, useRef, useState } from "react";
+import * as THREE from "three";
+import { OrbitControls } from "three/addons/controls/OrbitControls.js";
+
+interface DeskSceneProps {
+  rightcheatIconSrc: string;
+  fallbackSrc: string;
+  fallbackDarkSrc: string;
+}
+
+function isWebGLAvailable(): boolean {
+  try {
+    const canvas = document.createElement("canvas");
+    return !!(
+      window.WebGLRenderingContext &&
+      (canvas.getContext("webgl") || canvas.getContext("experimental-webgl"))
+    );
+  } catch {
+    return false;
+  }
+}
+
+function getTheme(): "light" | "dark" {
+  const theme = document.documentElement.getAttribute("data-theme");
+  return theme === "dark" ? "dark" : "light";
+}
+
+export default function DeskScene({
+  rightcheatIconSrc,
+  fallbackSrc,
+  fallbackDarkSrc,
+}: DeskSceneProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [webGLSupported, setWebGLSupported] = useState(true);
+  const [fallbackTheme, setFallbackTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    if (!isWebGLAvailable()) {
+      setWebGLSupported(false);
+      setFallbackTheme(getTheme());
+
+      const observer = new MutationObserver(() => {
+        setFallbackTheme(getTheme());
+      });
+      observer.observe(document.documentElement, {
+        attributes: true,
+        attributeFilter: ["data-theme"],
+      });
+      return () => observer.disconnect();
+    }
+
+    const container = containerRef.current;
+    if (!container) return;
+
+    // Scene setup
+    const scene = new THREE.Scene();
+
+    const getBackgroundColor = () =>
+      getTheme() === "dark" ? 0x1a1a1a : 0xffffff;
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setClearColor(getBackgroundColor());
+    renderer.shadowMap.enabled = true;
+
+    const containerWidth = container.clientWidth;
+    const height = Math.min(containerWidth * 0.55, 420);
+    renderer.setSize(containerWidth, height);
+    renderer.setPixelRatio(window.devicePixelRatio);
+    container.appendChild(renderer.domElement);
+
+    const camera = new THREE.PerspectiveCamera(
+      45,
+      containerWidth / height,
+      0.1,
+      1000,
+    );
+    camera.position.set(1, 5, 6);
+    camera.lookAt(0, 0, 0);
+
+    // Lighting
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.7);
+    scene.add(ambientLight);
+
+    const dirLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    dirLight.position.set(3, 5, 5);
+    scene.add(dirLight);
+
+    // Materials
+    const grayMat = new THREE.MeshLambertMaterial({ color: 0xd9d9d9 });
+    const darkGrayMat = new THREE.MeshLambertMaterial({ color: 0x888888 });
+    const whiteMat = new THREE.MeshLambertMaterial({ color: 0xffffff });
+
+    // Desk top
+    const deskTop = new THREE.Mesh(
+      new THREE.BoxGeometry(4.0, 0.15, 2.0),
+      grayMat,
+    );
+    deskTop.position.set(0, 0, 0);
+    scene.add(deskTop);
+
+    // Desk legs
+    const legGeom = new THREE.BoxGeometry(0.15, 1.5, 0.15);
+    const legPositions = [
+      [-1.85, -0.825, -0.85],
+      [1.85, -0.825, -0.85],
+      [-1.85, -0.825, 0.85],
+      [1.85, -0.825, 0.85],
+    ] as const;
+    for (const [x, y, z] of legPositions) {
+      const leg = new THREE.Mesh(legGeom, grayMat);
+      leg.position.set(x, y, z);
+      scene.add(leg);
+    }
+
+    // Monitor body
+    const monitor = new THREE.Mesh(
+      new THREE.BoxGeometry(1.5, 1.0, 0.08),
+      darkGrayMat,
+    );
+    monitor.position.set(-0.3, 0.65, -0.7);
+    scene.add(monitor);
+
+    // Monitor stand
+    const monitorStand = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.05, 0.08, 0.4, 8),
+      grayMat,
+    );
+    monitorStand.position.set(-0.3, 0.275, -0.7);
+    scene.add(monitorStand);
+
+    // Monitor base
+    const monitorBase = new THREE.Mesh(
+      new THREE.BoxGeometry(0.5, 0.05, 0.3),
+      grayMat,
+    );
+    monitorBase.position.set(-0.3, 0.075, -0.7);
+    scene.add(monitorBase);
+
+    // Mouse
+    const mouse = new THREE.Mesh(
+      new THREE.BoxGeometry(0.2, 0.08, 0.3),
+      grayMat,
+    );
+    mouse.position.set(0.8, 0.115, 0.1);
+    scene.add(mouse);
+
+    // Coffee cup body
+    const cupBody = new THREE.Mesh(
+      new THREE.CylinderGeometry(0.1, 0.08, 0.25, 16),
+      whiteMat,
+    );
+    cupBody.position.set(1.4, 0.2, -0.5);
+    scene.add(cupBody);
+
+    // Coffee cup handle
+    const cupHandle = new THREE.Mesh(
+      new THREE.TorusGeometry(0.06, 0.015, 8, 8, Math.PI),
+      whiteMat,
+    );
+    cupHandle.position.set(1.5, 0.2, -0.5);
+    cupHandle.rotation.y = Math.PI / 2;
+    scene.add(cupHandle);
+
+    // RightCheat icon plane
+    const textureLoader = new THREE.TextureLoader();
+    let iconPlane: THREE.Mesh | null = null;
+
+    textureLoader.load(rightcheatIconSrc, (texture) => {
+      const iconMat = new THREE.MeshBasicMaterial({
+        map: texture,
+        transparent: true,
+      });
+      iconPlane = new THREE.Mesh(new THREE.PlaneGeometry(0.45, 0.45), iconMat);
+      iconPlane.position.set(-0.3, 0.185, -0.1);
+      iconPlane.rotation.x = -Math.PI / 2;
+      scene.add(iconPlane);
+    });
+
+    // OrbitControls
+    const controls = new OrbitControls(camera, renderer.domElement);
+    controls.autoRotate = true;
+    controls.autoRotateSpeed = 0.5;
+    controls.enablePan = false;
+    controls.enableZoom = false;
+    controls.maxPolarAngle = Math.PI / 2.5;
+    controls.minPolarAngle = Math.PI / 6;
+
+    // Click detection
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    let pointerMoved = false;
+
+    const onPointerDown = () => {
+      pointerMoved = false;
+    };
+    const onPointerMove = () => {
+      pointerMoved = true;
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (pointerMoved || !iconPlane) return;
+
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+
+      raycaster.setFromCamera(pointer, camera);
+      const intersects = raycaster.intersectObject(iconPlane);
+      if (intersects.length > 0) {
+        window.location.href = "/portfolio/rightcheat";
+      }
+    };
+
+    const onPointerMoveHover = (e: PointerEvent) => {
+      if (!iconPlane) return;
+      const rect = renderer.domElement.getBoundingClientRect();
+      pointer.x = ((e.clientX - rect.left) / rect.width) * 2 - 1;
+      pointer.y = -((e.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(pointer, camera);
+      const intersects = raycaster.intersectObject(iconPlane);
+      renderer.domElement.style.cursor =
+        intersects.length > 0 ? "pointer" : "default";
+    };
+
+    renderer.domElement.addEventListener("pointerdown", onPointerDown);
+    renderer.domElement.addEventListener("pointermove", onPointerMove);
+    renderer.domElement.addEventListener("pointerup", onPointerUp);
+    renderer.domElement.addEventListener("pointermove", onPointerMoveHover);
+
+    // Theme observer
+    const themeObserver = new MutationObserver(() => {
+      renderer.setClearColor(getBackgroundColor());
+    });
+    themeObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    // Visibility change
+    const onVisibilityChange = () => {
+      controls.autoRotate = !document.hidden;
+    };
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    // Resize observer
+    const resizeObserver = new ResizeObserver(() => {
+      const w = container.clientWidth;
+      const h = Math.min(w * 0.55, 420);
+      renderer.setSize(w, h);
+      camera.aspect = w / h;
+      camera.updateProjectionMatrix();
+    });
+    resizeObserver.observe(container);
+
+    // Animation loop
+    let animId: number;
+    const animate = () => {
+      animId = requestAnimationFrame(animate);
+      controls.update();
+      renderer.render(scene, camera);
+    };
+    animate();
+
+    return () => {
+      cancelAnimationFrame(animId);
+      controls.dispose();
+      renderer.dispose();
+      resizeObserver.disconnect();
+      themeObserver.disconnect();
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+      renderer.domElement.removeEventListener("pointerdown", onPointerDown);
+      renderer.domElement.removeEventListener("pointermove", onPointerMove);
+      renderer.domElement.removeEventListener("pointerup", onPointerUp);
+      renderer.domElement.removeEventListener(
+        "pointermove",
+        onPointerMoveHover,
+      );
+      if (container.contains(renderer.domElement)) {
+        container.removeChild(renderer.domElement);
+      }
+    };
+  }, [rightcheatIconSrc]);
+
+  if (!webGLSupported) {
+    return (
+      <img
+        src={fallbackTheme === "dark" ? fallbackDarkSrc : fallbackSrc}
+        alt="A desk"
+        style={{ width: "100%", maxWidth: "750px", height: "auto" }}
+      />
+    );
+  }
+
+  return (
+    <div ref={containerRef} style={{ width: "100%", maxWidth: "750px" }} />
+  );
+}

--- a/src/components/organisms/SiteImage.astro
+++ b/src/components/organisms/SiteImage.astro
@@ -3,6 +3,7 @@ import deskImage from "@assets/desk.svg";
 import deskDarkImage from "@assets/desk-dark.svg";
 import rightcheatIcon from "@assets/portfolio/rightcheat/icon.svg";
 import Title from "@components/atoms/Title.astro";
+import DeskScene from "@components/organisms/DeskScene";
 ---
 
 <div class="site-image">
@@ -10,21 +11,12 @@ import Title from "@components/atoms/Title.astro";
     <Title />
   </div>
   <div class="desk">
-    <img
-      id="desk-image"
-      data-theme-element
-      src={deskImage.src}
-      data-light-src={deskImage.src}
-      data-dark-src={deskDarkImage.src}
-      alt="A desk"
+    <DeskScene
+      client:load
+      rightcheatIconSrc={rightcheatIcon.src}
+      fallbackSrc={deskImage.src}
+      fallbackDarkSrc={deskDarkImage.src}
     />
-    <a href="/portfolio/rightcheat"
-      ><img
-        class="product-on-desk"
-        src={rightcheatIcon.src}
-        alt="RightCheat"
-      /></a
-    >
   </div>
 </div>
 
@@ -39,36 +31,13 @@ import Title from "@components/atoms/Title.astro";
 
   .desk {
     margin-top: 40px;
-    position: relative;
     width: 100%;
     max-width: 750px;
-  }
-
-  #desk-image {
-    width: 100%;
-    height: auto;
-    max-width: 750px;
-  }
-
-  .product-on-desk {
-    position: absolute;
-    top: 5%;
-    left: 20%;
-    transform: translate(-50%, -50%);
-    width: 70px;
-  }
-
-  .product-on-desk:hover {
-    transform: translate(-50%, -50%) scale(1.1);
-    transition: transform 0.3s ease;
   }
 
   @media (max-width: 700px) {
     .desk {
       width: 90%;
-    }
-    .product-on-desk {
-      width: 50px;
     }
   }
 </style>

--- a/yarn.lock
+++ b/yarn.lock
@@ -257,6 +257,11 @@
   dependencies:
     fontkit "^2.0.2"
 
+"@dimforge/rapier3d-compat@~0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
+  integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
+
 "@emnapi/runtime@^1.7.0":
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.7.0.tgz#d7ef3832df8564fe5903bf0567aedbd19538ecbe"
@@ -1114,6 +1119,11 @@
   dependencies:
     tslib "^2.8.0"
 
+"@tweenjs/tween.js@~23.1.3":
+  version "23.1.3"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.3.tgz#eff0245735c04a928bb19c026b58c2a56460539d"
+  integrity sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==
+
 "@types/babel__core@^7.20.5":
   version "7.20.5"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.5.tgz#3df15f27ba85319caa07ba08d0721889bb39c017"
@@ -1243,6 +1253,24 @@
   dependencies:
     csstype "^3.0.2"
 
+"@types/stats.js@*":
+  version "0.17.4"
+  resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.4.tgz#1933e5ff153a23c7664487833198d685c22e791e"
+  integrity sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==
+
+"@types/three@^0.183.0":
+  version "0.183.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.183.0.tgz#9d7f77db69faeb57dbc4d96584f229bffcc6f9f1"
+  integrity sha512-AaGkvloQhxdrfMm/HbY8cpOz1K1jkEELn6zjFoY3yhAiC7zhhZE19+gDBybYwKk+GqXmWKxqDCB43NqyW3+QZw==
+  dependencies:
+    "@dimforge/rapier3d-compat" "~0.12.0"
+    "@tweenjs/tween.js" "~23.1.3"
+    "@types/stats.js" "*"
+    "@types/webxr" ">=0.5.17"
+    "@webgpu/types" "*"
+    fflate "~0.8.2"
+    meshoptimizer "~1.0.1"
+
 "@types/unist@*", "@types/unist@^3.0.0":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-3.0.3.tgz#acaab0f919ce69cce629c2d4ed2eb4adc1b6c20c"
@@ -1252,6 +1280,11 @@
   version "2.0.11"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.11.tgz#11af57b127e32487774841f7a4e54eab166d03c4"
   integrity sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==
+
+"@types/webxr@>=0.5.17":
+  version "0.5.24"
+  resolved "https://registry.yarnpkg.com/@types/webxr/-/webxr-0.5.24.tgz#734d5d90dadc5809a53e422726c60337fa2f4a44"
+  integrity sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==
 
 "@typescript-eslint/eslint-plugin@^8.42.0":
   version "8.46.3"
@@ -1367,6 +1400,11 @@
     "@rolldown/pluginutils" "1.0.0-beta.27"
     "@types/babel__core" "^7.20.5"
     react-refresh "^0.17.0"
+
+"@webgpu/types@*":
+  version "0.1.69"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.69.tgz#6b849bf370a1f29c78bd3aeba8e84c1150b237f2"
+  integrity sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ==
 
 acorn-jsx@^5.0.0, acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -2214,6 +2252,11 @@ fdir@^6.4.4, fdir@^6.5.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.5.0.tgz#ed2ab967a331ade62f18d077dae192684d50d350"
   integrity sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==
 
+fflate@~0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.8.2.tgz#fc8631f5347812ad6028bbe4a2308b2792aa1dea"
+  integrity sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==
+
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -3007,6 +3050,11 @@ merge2@^1.3.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+meshoptimizer@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-1.0.1.tgz#c3ef0d509a8b84ac562493dba5a108fd67fa76dc"
+  integrity sha512-Vix+QlA1YYT3FwmBBZ+49cE5y/b+pRrcXKqGpS5ouh33d3lSp2PoTpCw19E0cKDFWalembrHnIaZetf27a+W2g==
 
 micromark-core-commonmark@^2.0.0:
   version "2.0.3"
@@ -4217,6 +4265,11 @@ synckit@^0.11.0:
   integrity sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==
   dependencies:
     "@pkgr/core" "^0.2.9"
+
+three@^0.183.0:
+  version "0.183.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.183.0.tgz#dea9c721a53250e28e99114bb7b46dc2bb01dc91"
+  integrity sha512-G6SH2jfefIVa2YI4JL2VbgQhrrbp1A8dRc7lr3PW827kdVyaX2RgH6M5FmjmdVFLgSHppyg3OYOZdTfWElle+g==
 
 tiny-inflate@^1.0.0, tiny-inflate@^1.0.3:
   version "1.0.3"


### PR DESCRIPTION
## 概要

Closes #2

トップページのヒーロービジュアルとして表示されていた静的なデスクSVG画像を、Three.jsを使ったインタラクティブな3Dシーンに置き換えました。

## 変更内容

- **新規作成**: `src/components/organisms/DeskScene.tsx`
  - Three.jsによる3Dデスクシーン（机・モニター・マウス・コーヒーカップ等）
  - OrbitControls による自動回転（`autoRotateSpeed: 0.5`）とマウスドラッグ視点操作
  - RightCheatアイコンをデスク上に表示し、クリックで `/portfolio/rightcheat` へ遷移
  - Raycaster によるクリック・ホバー検知（ポインターカーソル変更）
  - `MutationObserver` でテーマ(ライト/ダーク)に応じた背景色自動切り替え
  - `ResizeObserver` によるレスポンシブなcanvasリサイズ
  - タブ非アクティブ時に自動回転を停止（`visibilitychange`）
  - WebGL非対応環境向けのフォールバック（静的SVG表示）
- **更新**: `src/components/organisms/SiteImage.astro`
  - 静的な `#desk-image` imgタグと `.product-on-desk` リンクを削除
  - `DeskScene` コンポーネント（`client:load`）に置き換え
- **更新**: `eslint.config.js`
  - 新規ブラウザAPIグローバル変数を追加（`HTMLDivElement`, `ResizeObserver`, `PointerEvent`, `requestAnimationFrame`, `cancelAnimationFrame`）
- **依存追加**: `three@0.183.0`, `@types/three@0.183.0`

## テスト手順

1. `yarn dev` で開発サーバーを起動
2. http://localhost:4321 でトップページを確認:
   - [x] 3Dデスクシーンが表示されること
   - [x] 自動回転していること
   - [x] マウスドラッグで視点操作できること
   - [x] RightCheatアイコンがデスク上に表示され、クリックで `/portfolio/rightcheat` に遷移すること
   - [x] テーマ切り替え（ライト/ダーク）で背景色が切り替わること
   - [x] ウィンドウリサイズでcanvasが追従すること
3. `yarn build` でビルドエラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)